### PR TITLE
Prohibit bare tuples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
   (`Issue #45 <https://github.com/PyCQA/flake8-commas/issue/45>`_)
 - Update URL to https://github.com/PyCQA/flake8-commas/.
   (`Issue #51 <https://github.com/PyCQA/flake8-commas/pull/51>`_)
+- Add check for bare tuples - C818
+  (`PR #52 <https://github.com/PyCQA/flake8-commas/pull/52>`_)
 
 
 1.0.0 (2018-01-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
   (`Issue #45 <https://github.com/PyCQA/flake8-commas/issue/45>`_)
 - Update URL to https://github.com/PyCQA/flake8-commas/.
   (`Issue #51 <https://github.com/PyCQA/flake8-commas/pull/51>`_)
-- Add check for bare tuples - C818
+- Add check for trailing commas on bare tuples - C818
   (`PR #52 <https://github.com/PyCQA/flake8-commas/pull/52>`_)
 
 

--- a/README.rst
+++ b/README.rst
@@ -18,20 +18,20 @@ Errors
 Different versions of python require commas in different places. Ignore the
 errors for languages you don't use in your flake8 config:
 
-+------+---------------------------------------+
-| Code | message                               |
-+======+=======================================+
-| C812 | missing trailing comma                |
-+------+---------------------------------------+
-| C813 | missing trailing comma in Python 3    |
-+------+---------------------------------------+
-| C814 | missing trailing comma in Python 2    |
-+------+---------------------------------------+
-| C815 | missing trailing comma in Python 3.5+ |
-+------+---------------------------------------+
-| C816 | missing trailing comma in Python 3.6+ |
-+------+---------------------------------------+
-| C818 | bare tuple prohibited                 |
-+------+---------------------------------------+
-| C819 | trailing comma prohibited             |
-+------+---------------------------------------+
++------+-----------------------------------------+
+| Code | message                                 |
++======+=========================================+
+| C812 | missing trailing comma                  |
++------+-----------------------------------------+
+| C813 | missing trailing comma in Python 3      |
++------+-----------------------------------------+
+| C814 | missing trailing comma in Python 2      |
++------+-----------------------------------------+
+| C815 | missing trailing comma in Python 3.5+   |
++------+-----------------------------------------+
+| C816 | missing trailing comma in Python 3.6+   |
++------+-----------------------------------------+
+| C818 | trailing comma on bare tuple prohibited |
++------+-----------------------------------------+
+| C819 | trailing comma prohibited               |
++------+-----------------------------------------+

--- a/README.rst
+++ b/README.rst
@@ -31,5 +31,7 @@ errors for languages you don't use in your flake8 config:
 +------+---------------------------------------+
 | C816 | missing trailing comma in Python 3.6+ |
 +------+---------------------------------------+
+| C818 | bare tuple prohibited                 |
++------+---------------------------------------+
 | C819 | trailing comma prohibited             |
 +------+---------------------------------------+

--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -276,7 +276,7 @@ def get_comma_errors(tokens):
         if bare_comma_prohibited:
             end_row, end_col = prev_1.token.end
             yield {
-                'message': 'C818 bare tuple prohibited',
+                'message': 'C818 trailing comma on bare tuple prohibited',
                 'line': end_row,
                 'col': end_col,
             }

--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -260,6 +260,11 @@ def get_comma_errors(tokens):
                 (stack[-1].comma not in TUPLE_ISH or stack[-1].n > 1)
             ) or stack[-1].comma == LAMBDA_EXPR and token.type == COLON
         )
+        comma_prohibited = comma_prohibited or (
+            token.token.type == tokenize.NEWLINE and
+            prev_1.type == COMMA
+        )
+
         if comma_prohibited:
             end_row, end_col = prev_1.token.end
             yield {

--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -260,15 +260,24 @@ def get_comma_errors(tokens):
                 (stack[-1].comma not in TUPLE_ISH or stack[-1].n > 1)
             ) or stack[-1].comma == LAMBDA_EXPR and token.type == COLON
         )
-        comma_prohibited = comma_prohibited or (
-            token.token.type == tokenize.NEWLINE and
-            prev_1.type == COMMA
-        )
 
         if comma_prohibited:
             end_row, end_col = prev_1.token.end
             yield {
                 'message': 'C819 trailing comma prohibited',
+                'line': end_row,
+                'col': end_col,
+            }
+
+        bare_comma_prohibited = (
+            token.token.type == tokenize.NEWLINE and
+            prev_1.type == COMMA
+        )
+
+        if bare_comma_prohibited:
+            end_row, end_col = prev_1.token.end
+            yield {
+                'message': 'C818 bare tuple prohibited',
                 'line': end_row,
                 'col': end_col,
             }

--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -260,7 +260,6 @@ def get_comma_errors(tokens):
                 (stack[-1].comma not in TUPLE_ISH or stack[-1].n > 1)
             ) or stack[-1].comma == LAMBDA_EXPR and token.type == COLON
         )
-
         if comma_prohibited:
             end_row, end_col = prev_1.token.end
             yield {

--- a/test/data/bare.py
+++ b/test/data/bare.py
@@ -1,0 +1,65 @@
+bar = 1, 2
+
+foo = 1
+
+foo = (1,)
+
+foo = 1,
+
+bar = 1; foo = bar,
+
+foo = (
+3,
+4,
+)
+bar = 10,
+
+foo = 3,
+bar = 10,
+foo_bar = 2,
+
+foo = 3,
+bar = 10
+foo_bar = 2,
+
+foo = 3,
+bar = 10,
+foo_bar = 2
+
+foo = 3 
+bar = 10 
+foo_bar = 2,
+
+class A(object):
+ foo = 3
+ bar = 10,
+ foo_bar = 2
+
+a = ('a',)
+from foo import bar, baz
+
+a = ('a',)
+('b', 'c')
+
+a = ('a',)
+('b', 'c')
+
+
+"""
+foo
+"""
+bah = 1
+
+base_url = reverse(
+'test',
+args=(pk,)
+)
+
+base_url = reverse(
+'test',
+args=pk,
+)
+
+group_by = function_call('arg'),
+
+group_by = ('foobar' * 3),

--- a/test/data/bare.py
+++ b/test/data/bare.py
@@ -12,23 +12,8 @@ foo = (
 3,
 4,
 )
-bar = 10,
 
-foo = 3,
-bar = 10,
-foo_bar = 2,
-
-foo = 3,
-bar = 10
-foo_bar = 2,
-
-foo = 3,
-bar = 10,
-foo_bar = 2
-
-foo = 3 
-bar = 10 
-foo_bar = 2,
+foo = 3, 
 
 class A(object):
  foo = 3
@@ -36,29 +21,8 @@ class A(object):
  foo_bar = 2
 
 a = ('a',)
+
 from foo import bar, baz
-
-a = ('a',)
-('b', 'c')
-
-a = ('a',)
-('b', 'c')
-
-
-"""
-foo
-"""
-bah = 1
-
-base_url = reverse(
-'test',
-args=(pk,)
-)
-
-base_url = reverse(
-'test',
-args=pk,
-)
 
 group_by = function_call('arg'),
 

--- a/test/data/prohibited.py
+++ b/test/data/prohibited.py
@@ -27,5 +27,3 @@ image[:,]
 image[:,:,]
 
 lambda x, :
-
-baz = 0,

--- a/test/data/prohibited.py
+++ b/test/data/prohibited.py
@@ -27,3 +27,5 @@ image[:,]
 image[:,:,]
 
 lambda x, :
+
+baz = 0,

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -241,6 +241,7 @@ def test_prohibited():
        {'col': 6, 'line': 21, 'message': 'C819 trailing comma prohibited'},
        {'col': 10, 'line': 27, 'message': 'C819 trailing comma prohibited'},
        {'col': 9, 'line': 29, 'message': 'C819 trailing comma prohibited'},
+       {'col': 8, 'line': 31, 'message': 'C819 trailing comma prohibited'},
     ]
 
 

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -241,7 +241,27 @@ def test_prohibited():
        {'col': 6, 'line': 21, 'message': 'C819 trailing comma prohibited'},
        {'col': 10, 'line': 27, 'message': 'C819 trailing comma prohibited'},
        {'col': 9, 'line': 29, 'message': 'C819 trailing comma prohibited'},
-       {'col': 8, 'line': 31, 'message': 'C819 trailing comma prohibited'},
+    ]
+
+
+def test_bare():
+    filename = get_absolute_path('data/bare.py')
+    assert list(get_comma_errors(get_tokens(filename))) == [
+       {'col': 8, 'line': 7, 'message': 'C818 bare tuple prohibited'},
+       {'col': 19, 'line': 9, 'message': 'C818 bare tuple prohibited'},
+       {'col': 9, 'line': 15, 'message': 'C818 bare tuple prohibited'},
+       {'col': 8, 'line': 17, 'message': 'C818 bare tuple prohibited'},
+       {'col': 9, 'line': 18, 'message': 'C818 bare tuple prohibited'},
+       {'col': 12, 'line': 19, 'message': 'C818 bare tuple prohibited'},
+       {'col': 8, 'line': 21, 'message': 'C818 bare tuple prohibited'},
+       {'col': 12, 'line': 23, 'message': 'C818 bare tuple prohibited'},
+       {'col': 8, 'line': 25, 'message': 'C818 bare tuple prohibited'},
+       {'col': 9, 'line': 26, 'message': 'C818 bare tuple prohibited'},
+       {'col': 12, 'line': 31, 'message': 'C818 bare tuple prohibited'},
+       {'col': 10, 'line': 35, 'message': 'C818 bare tuple prohibited'},
+       {'col': 10, 'line': 55, 'message': 'C812 missing trailing comma'},
+       {'col': 32, 'line': 63, 'message': 'C818 bare tuple prohibited'},
+       {'col': 26, 'line': 65, 'message': 'C818 bare tuple prohibited'},
     ]
 
 

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -247,12 +247,18 @@ def test_prohibited():
 def test_bare():
     filename = get_absolute_path('data/bare.py')
     assert list(get_comma_errors(get_tokens(filename))) == [
-       {'col': 8, 'line': 7, 'message': 'C818 bare tuple prohibited'},
-       {'col': 19, 'line': 9, 'message': 'C818 bare tuple prohibited'},
-       {'col': 8, 'line': 16, 'message': 'C818 bare tuple prohibited'},
-       {'col': 10, 'line': 20, 'message': 'C818 bare tuple prohibited'},
-       {'col': 32, 'line': 27, 'message': 'C818 bare tuple prohibited'},
-       {'col': 26, 'line': 29, 'message': 'C818 bare tuple prohibited'},
+       {'col': 8, 'line': 7,
+        'message': 'C818 trailing comma on bare tuple prohibited'},
+       {'col': 19, 'line': 9,
+        'message': 'C818 trailing comma on bare tuple prohibited'},
+       {'col': 8, 'line': 16,
+        'message': 'C818 trailing comma on bare tuple prohibited'},
+       {'col': 10, 'line': 20,
+        'message': 'C818 trailing comma on bare tuple prohibited'},
+       {'col': 32, 'line': 27,
+        'message': 'C818 trailing comma on bare tuple prohibited'},
+       {'col': 26, 'line': 29,
+        'message': 'C818 trailing comma on bare tuple prohibited'},
     ]
 
 

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -249,19 +249,10 @@ def test_bare():
     assert list(get_comma_errors(get_tokens(filename))) == [
        {'col': 8, 'line': 7, 'message': 'C818 bare tuple prohibited'},
        {'col': 19, 'line': 9, 'message': 'C818 bare tuple prohibited'},
-       {'col': 9, 'line': 15, 'message': 'C818 bare tuple prohibited'},
-       {'col': 8, 'line': 17, 'message': 'C818 bare tuple prohibited'},
-       {'col': 9, 'line': 18, 'message': 'C818 bare tuple prohibited'},
-       {'col': 12, 'line': 19, 'message': 'C818 bare tuple prohibited'},
-       {'col': 8, 'line': 21, 'message': 'C818 bare tuple prohibited'},
-       {'col': 12, 'line': 23, 'message': 'C818 bare tuple prohibited'},
-       {'col': 8, 'line': 25, 'message': 'C818 bare tuple prohibited'},
-       {'col': 9, 'line': 26, 'message': 'C818 bare tuple prohibited'},
-       {'col': 12, 'line': 31, 'message': 'C818 bare tuple prohibited'},
-       {'col': 10, 'line': 35, 'message': 'C818 bare tuple prohibited'},
-       {'col': 10, 'line': 55, 'message': 'C812 missing trailing comma'},
-       {'col': 32, 'line': 63, 'message': 'C818 bare tuple prohibited'},
-       {'col': 26, 'line': 65, 'message': 'C818 bare tuple prohibited'},
+       {'col': 8, 'line': 16, 'message': 'C818 bare tuple prohibited'},
+       {'col': 10, 'line': 20, 'message': 'C818 bare tuple prohibited'},
+       {'col': 32, 'line': 27, 'message': 'C818 bare tuple prohibited'},
+       {'col': 26, 'line': 29, 'message': 'C818 bare tuple prohibited'},
     ]
 
 


### PR DESCRIPTION
We've had many production failures due to inadvertently having trailing commas on a line, resulting in a tuple where the single object was expected.

I'd like a way to check for bare trailing commas. This PR reuses the existing C819 error for this case, but I'm open to creating a new error code for it.